### PR TITLE
Resize bounding box when downloading bases on size of selection rectangle

### DIFF
--- a/src/pages/DownloadScreen.tsx
+++ b/src/pages/DownloadScreen.tsx
@@ -9,9 +9,9 @@ import { AppScreen } from '../components/AppScreen'
 import { useLandmarks } from '../hooks/useLandmarks'
 import { WarningPopup } from '../components/WarningPopup'
 import { useMap } from '../contexts/MapContext'
+import { GeoSearchField } from '../components/GeoSearchField'
 
 import '../components/css/DownloadScreen.css'
-import { GeoSearchField } from '../components/GeoSearchField'
 
 const pageName = 'Download area'
 
@@ -28,10 +28,33 @@ export function DownloadScreen() {
 
   function handleDownload() {
     if (areaName && map && map.current) {
+      const bounds = map.current.getBounds()
+      const northWest = bounds.getNorthWest()
+      const southEast = bounds.getSouthEast()
+
+      const areaHeight = northWest.lat - southEast.lat
+      const areaWidth = northWest.lng - southEast.lng
+
+      const halfAdjustedHeight = (areaHeight * 0.65) / 2
+      const halfAdjustedWidth = (areaWidth * 0.75) / 2
+
+      const center = bounds.getCenter()
+
+      const newNorthWest = {
+        lat: center.lat + halfAdjustedHeight,
+        lng: center.lng + halfAdjustedWidth,
+      }
+
+      const newSouthEast = {
+        lat: center.lat - halfAdjustedHeight,
+        lng: center.lng - halfAdjustedWidth,
+      }
+
       downloadNewLandmarks({
         areaName: areaName,
-        boundingBox: { topLeft: map.current.getBounds().getNorthWest(), bottomRight: map.current.getBounds().getSouthEast() },
+        boundingBox: { topLeft: newNorthWest, bottomRight: newSouthEast },
       })
+
       setIsModalOpen(false)
       setAreaName('')
     }


### PR DESCRIPTION
### 🛠 Changes being made
- Instead of sending the map bounds as bounding parameter for downloading send the inner rectangle bounds

### ✨ What's the context?
When pressing download the area that would be downloaded would include the area inside the screen but outside of the selection rectangle.

### 🧪 Testing
- Extensions still work
- Logged changed coordinates and verified with osm
- Made the clip a bit to big so that it will always be a little bigger than the selection rectangle

### 🏎 Quality check
- [X] Are there any errors, console logs, debuggers or leftover code in your changes?
- [X] Did you update the documentation for your code?

### 🐛 Linked issues
- Closes #68 