### PR TITLE
Dark mode styling fix for geosearch and zoom control

### DIFF
--- a/src/components/GeoSearchField.tsx
+++ b/src/components/GeoSearchField.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { GeoSearchControl, OpenStreetMapProvider } from 'leaflet-geosearch'
 import { useMap } from '../contexts/MapContext'
 import 'leaflet-geosearch/dist/geosearch.css'
+import './css/GeoSearchField.css'
 
 export function GeoSearchField() {
   const map = useMap()

--- a/src/components/css/GeoSearchField.css
+++ b/src/components/css/GeoSearchField.css
@@ -1,0 +1,34 @@
+/* 
+ * Meant to overide the default css of the GeoSearchField component
+ * so that it fits the theme of the application (and thus also dark-mode)
+ *
+ * Feel free to change the css to fit your needs
+ */
+
+.leaflet-control-geosearch > form {
+    background-color: var(--ion-color-light, var(--ion-background-color, #fff));
+}
+
+.leaflet-control-geosearch .glass {
+    background-color: var(--ion-color-light, var(--ion-background-color, #fff)) !important;
+    color: var(--ion-color-dark) !important;
+}
+
+.leaflet-control-geosearch .glass::placeholder {
+    color: var(--ion-color-medium-tint) !important;
+}
+
+.leaflet-control-geosearch .reset {
+    background-color: var(--ion-color-light, var(--ion-background-color, #fff)) !important;
+    color: var(--ion-color-dark) !important;
+}
+
+.leaflet-control-geosearch .results {
+    background-color: var(--ion-color-light, var(--ion-background-color, #fff));
+    color: var(--ion-color-dark);
+}
+
+.leaflet-control-geosearch .results > div:hover {
+    background-color: var(--ion-color-light-shade);
+    border-color: var(--ion-color-light-tint);
+}

--- a/src/components/css/LeafletMap.css
+++ b/src/components/css/LeafletMap.css
@@ -56,3 +56,11 @@
 .popup__text__center ion-text {
   margin-left: 1em;
 }
+
+/* override styling of leafletjs elements */
+
+.leaflet-control-zoom > a {
+  background-color: var(--ion-color-light, var(--ion-background-color, #fff)) !important;
+  color: var(--ion-color-dark) !important;
+  border-color: var(--ion-color-light-tint) !important;
+}

--- a/src/components/css/LeafletMap.css
+++ b/src/components/css/LeafletMap.css
@@ -59,8 +59,35 @@
 
 /* override styling of leafletjs elements */
 
+.leaflet-control-zoom {
+  --accent: var(--ion-color-light-tint);
+
+  box-shadow: 0px 0px 10px rgba(0, 0, 0, 0.4) !important;
+  border-color: var(--ion-color-light, var(--ion-background-color, #fff)) !important;
+}
+
 .leaflet-control-zoom > a {
   background-color: var(--ion-color-light, var(--ion-background-color, #fff)) !important;
   color: var(--ion-color-dark) !important;
-  border-color: var(--ion-color-light-tint) !important;
+  border: none;
+}
+
+.leaflet-control-zoom > a:first-child {
+  border-bottom: 1px solid var(--accent) !important;
+}
+
+.leaflet-control-zoom > a:hover {
+  background-color: var(--accent) !important;
+}
+
+.leaflet-control-zoom > a.leaflet-disabled {
+  background-color: var(--accent) !important;
+  color: var(--ion-color-medium) !important;
+}
+
+/* gotta do this cuz the colors look ugly otherwise */
+@media (prefers-color-scheme: light) {
+  .leaflet-control-zoom {
+    --accent: var(--ion-color-light-shade);
+  }
 }

--- a/src/components/css/LeafletMap.css
+++ b/src/components/css/LeafletMap.css
@@ -76,10 +76,6 @@
   border-bottom: 1px solid var(--accent) !important;
 }
 
-.leaflet-control-zoom > a:hover {
-  background-color: var(--accent) !important;
-}
-
 .leaflet-control-zoom > a.leaflet-disabled {
   background-color: var(--accent) !important;
   color: var(--ion-color-medium) !important;


### PR DESCRIPTION
### 🛠 Changes

I tried finding if there was any way to change the styling build into leaflet js and the geosearch expansion, but couldn't find anything. So I manually overwrote the CSS of both to fix the styling and link it to ionic's variables.

This way the colors are light in light mode and dark in dark mode.

### 📸 Screenshots
**before:**

![image](https://github.com/OSTA-group/osta/assets/116001910/63aaac79-069f-4d5a-a231-fcc70a6ecfb0)

**after:**

![image](https://github.com/OSTA-group/osta/assets/116001910/a1871dba-4f9f-454c-b027-ff087855d18e)

### 🚀 Tests

It's just styling changes so there is no real need for tests besides just looking at it.

**Important Note: I did use the web version. It has not been tested on android**

### 🐛 Linked issues
- Closes #76
